### PR TITLE
Initial Changes/Fixes

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -91,3 +91,8 @@ attack={
 [layer_names]
 
 2d_physics/layer_4="collisions"
+2d_physics/layer_10="transitions"
+
+[rendering]
+
+textures/canvas_textures/default_texture_filter=0

--- a/scenes/UI Menus/Pause Screen/pause_screen.gd
+++ b/scenes/UI Menus/Pause Screen/pause_screen.gd
@@ -7,15 +7,22 @@ extends Control
 
 func _ready(): 
 	settings.hide()
+	for child in $PanelContainer/VBoxContainer.get_children():
+		child.disabled = true
 	$AnimationPlayer.play("RESET")
 
 func resume():  
 	resume_button.release_focus()
 	get_tree().paused = false
+	for child in $PanelContainer/VBoxContainer.get_children():
+		child.disabled = true
 	$AnimationPlayer.play_backwards("blur")
+	
 
 func pause():
-	get_tree().paused = true 
+	get_tree().paused = true
+	for child in $PanelContainer/VBoxContainer.get_children():
+		child.disabled = false
 	$AnimationPlayer.play("blur")
 
 func testEsc():

--- a/scenes/UI Menus/Volume Slider/volume_slider.gd
+++ b/scenes/UI Menus/Volume Slider/volume_slider.gd
@@ -10,8 +10,8 @@ func _ready() -> void:
 	
 	value = db_to_linear(AudioServer.get_bus_volume_db(bus_index))
 
-func _on_value_changed(value: float) -> void: 
+func _on_value_changed(newValue: float) -> void: 
 		AudioServer.set_bus_volume_db( 
 			bus_index, 
-			linear_to_db(value)
+			linear_to_db(newValue)
 		)

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -17,30 +17,32 @@ var facing_right = true
 func _ready(): 
 	connect("facing_changed", Callable($AnimatedSprite2D2, "_on_facing_changed"))
 
-func set_facing() -> void: 
-	if(Input.is_action_pressed("move_left") and Input.is_action_pressed("move_right")): 
-		#print("nuh uh")
-		pass
-	elif (Input.is_action_pressed("move_right")):
+func set_facing(facingAxis: float) -> void: 
+	if (facingAxis > 0):
 		#print("right")  
 		if (!facing_right): 
 			facing_right = true 
 			emit_signal("facing_changed", facing_right)
-	elif (Input.is_action_pressed("move_left")):
+	elif (facingAxis < 0):
 		#print("left")
 		if (facing_right): 
 			facing_right = false 
 			emit_signal("facing_changed", facing_right)
 
 func _physics_process(delta):
-	set_facing()
-	var walk = speed * (Input.get_axis("move_left", "move_right"))
+	var facingAxis = Input.get_axis("move_left", "move_right")
+	set_facing(facingAxis)
+	var walk = speed * facingAxis
 	if abs(walk) < speed * 0.2:
 		velocity.x = move_toward(velocity.x, 0, stop_force * delta)
 	else:
 		velocity.x += walk * delta
 	velocity.x = clamp(velocity.x, -max_run_speed, max_run_speed) if Input.is_action_pressed("run") else clamp(velocity.x, -max_walk_speed, max_walk_speed)
 	$AnimatedSprite2D.scale = Vector2(0.2, 0.1) if Input.is_action_pressed("crouch_look_down") else Vector2(0.2, 0.2)
+	
+	# This shrinks the player so they can go under shorter areas, whoever, it gets stuck on the floor
+	#$CollisionShape2D.scale = Vector2(1, 0.5) if Input.is_action_pressed("crouch_look_down") else Vector2(1, 1)
+	#$HurtBox/CollisionShape2D.scale = Vector2(1, 0.5) if Input.is_action_pressed("crouch_look_down") else Vector2(1, 1)
 	 
 	
 	velocity.y += gravity * delta

--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -98,6 +98,9 @@ animations = [{
 size = Vector2(80.6402, 359.455)
 
 [node name="Player" type="CharacterBody2D" node_paths=PackedStringArray("stone")]
+collision_layer = 513
+floor_constant_speed = true
+floor_snap_length = 12.0
 script = ExtResource("1_c623h")
 stone = NodePath("AudioStreamPlayer2D")
 metadata/_edit_group_ = true

--- a/scenes/prologue/throne-room/throne-room.tscn
+++ b/scenes/prologue/throne-room/throne-room.tscn
@@ -997,7 +997,6 @@ shadow_enabled = true
 texture = ExtResource("7_35vq6")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
-visible = false
 
 [node name="PauseScreen" parent="CanvasLayer" instance=ExtResource("10_p66qs")]
 offset_left = 1.0

--- a/scenes/prologue/tutorial-one/tutorial-one.tscn
+++ b/scenes/prologue/tutorial-one/tutorial-one.tscn
@@ -602,6 +602,7 @@ offset_bottom = 7.0
 
 [node name="ChangeScene" type="Area2D" parent="."]
 position = Vector2(2329, 811)
+collision_mask = 512
 script = ExtResource("13_1mlff")
 path = "res://scenes/prologue/tutorial-two/tutorial-two.tscn"
 

--- a/scenes/prologue/tutorial-two/tutorial-two.tscn
+++ b/scenes/prologue/tutorial-two/tutorial-two.tscn
@@ -759,6 +759,7 @@ grow_vertical = 1
 
 [node name="ChangeScene" type="Area2D" parent="."]
 position = Vector2(1246, -265)
+collision_mask = 512
 script = ExtResource("11_jyxw7")
 path = "res://scenes/prologue/throne-room/throne-room.tscn"
 

--- a/scenes/scene_trigger.gd
+++ b/scenes/scene_trigger.gd
@@ -2,5 +2,6 @@ extends Area2D
 
 @export var path: String
 
-func _on_body_entered(_body: PhysicsBody2D) -> void:
+func _on_body_entered(_body) -> void:
+	print(type_string(typeof(_body)))
 	get_tree().call_deferred("change_scene_to_file", path)

--- a/scenes/title-screen/title-screen.tscn
+++ b/scenes/title-screen/title-screen.tscn
@@ -69,3 +69,4 @@ size_flags_vertical = 0
 
 [connection signal="pressed" from="PlayButton" to="PlayButton" method="_on_pressed"]
 [connection signal="pressed" from="SettingsButton" to="Settings" method="_on_settings_button_pressed"]
+[connection signal="pressed" from="ExitButton" to="ExitButton" method="_on_pressed"]


### PR DESCRIPTION
- Pixel art looked blurry, so I changed the rendering texture filter from Linear to Nearest. Now the pixel art is nice and crisp
- Added a transitions physics layer
- Streamlined a few things in the player.gd to simplify it a bit
- Prototyped a fix with crouching
- Made slope movement constant and sticks to the ground on a decline
- I re-enabled the esc menu in the throne room so I could close the game
- I changed the transition areas to only watch for layer 10 (transitions), which I set the player to also be in
- Fixed an error in scene_trigger.gd where the incoming _body object couldn't be made into a different object, fixed with a specific transitions layer instead of the normal layer 1 deal
- The exit button works on the title screen. The signal wasn't connected to the script
- You were still able to click the pause menu buttons while they were invisible, so I disabled them when they are invisible (or more specifically, when they become invisible)
- I renamed value to newValue in volume_slider.gd because it was shadowing an established variable in the Slider class

If I misinterpreted any aspects, such as constant speed on slopes and sticking to slopes, please let me know.